### PR TITLE
Fix: Force dotfiles re-installation in Codespaces(from jules)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   },
   // "forwardPorts": [4000],
   // "postCreateCommand": "",
-  "postStartCommand": "sh ./setup.sh",
+  "postStartCommand": "rm -rf /workspaces/.codespaces/.persistedshare/dotfiles && echo 'Cleaned dotfiles target path for re-installation.' && sh ./setup.sh",
   // "postAttachCommand": "",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
The Codespace was entering recovery mode due to a potential issue with the dotfiles installation, where a marker indicated they were installed, but the installation might have been corrupt.

This change modifies the .devcontainer/devcontainer.json to prepend a command to the 'postStartCommand'. The added command (`rm -rf /workspaces/.codespaces/.persistedshare/dotfiles`) removes the target directory where Codespaces clones the dotfiles. This should ensure that Codespaces performs a fresh clone and installation of the dotfiles upon container startup, resolving the configuration error.

https://jules.google.com/task/3902533460217602463